### PR TITLE
Fix tag extract regrex

### DIFF
--- a/lib/content_for_once/helpers.rb
+++ b/lib/content_for_once/helpers.rb
@@ -5,11 +5,14 @@ module ContentForOnce
       name = name.to_sym
 
       @contents[name].concat(capture(&block))
-      @contents[name] = @contents[name].scan(/<.*?>/).uniq.join
+      @contents[name] = @contents[name].scan(/<\w+(?:\s+[^>]+)?\/?>*<\/\w+>|<\w+(?:\s+[^>]+)?\/?>/).uniq.join
 
       @contents.each do |name, content|
         # ref: https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/capture_helper.rb#L149
-        @view_flow.set(name, content)
+        _content = @view_flow.get(name).presence || ''
+        _content.concat(content.html_safe)
+        _content = _content.scan(/<\w+(?:\s+[^>]+)?\/?>*<\/\w+>|<\w+(?:\s+[^>]+)?\/?>/).uniq.join
+        @view_flow.set(name, _content)
       end
     end
   end

--- a/lib/content_for_once/version.rb
+++ b/lib/content_for_once/version.rb
@@ -1,3 +1,3 @@
 module ContentForOnce
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/content_for_once_spec.rb
+++ b/spec/content_for_once_spec.rb
@@ -5,14 +5,14 @@ describe ContentForOnce do
     expect(ContentForOnce::VERSION).not_to be nil
   end
 
+  let(:action_view) { ActionView::Base.new { include ContentForOnce::Helpers } }
+
   context 'call `content_for_once` in the view' do
-    let(:action_view) { ActionView::Base.new { include ContentForOnce::Helpers } }
+    let(:first_given_block) { "<link rel='stylesheet' href='example1.css'/>".html_safe }
+    let(:second_given_block) { "<link rel='stylesheet' href='example1.css'/><link rel='stylesheet' href='example2.css'></link>".html_safe }
+    let(:third_given_block) { "<link rel='stylesheet' href='example2.css'></link><link rel='stylesheet' href='example3.css'/>".html_safe }
 
-    let(:first_given_block) { "<link rel='stylesheet' href='example1.css'>".html_safe }
-    let(:second_given_block) { "<link rel='stylesheet' href='example1.css'><link rel='stylesheet' href='example2.css'>".html_safe }
-    let(:third_given_block) { "<link rel='stylesheet' href='example2.css'><link rel='stylesheet' href='example3.css'>".html_safe }
-
-    let(:expected_tags) { "<link rel='stylesheet' href='example1.css'><link rel='stylesheet' href='example2.css'><link rel='stylesheet' href='example3.css'>" }
+    let(:expected_tags) { "<link rel='stylesheet' href='example1.css'/><link rel='stylesheet' href='example2.css'></link><link rel='stylesheet' href='example3.css'/>" }
 
     it 'embeds each unique tags only once' do
       action_view.content_for_once :css do
@@ -23,6 +23,25 @@ describe ContentForOnce do
       end
       action_view.content_for_once :css do
         third_given_block
+      end
+
+      expect(action_view.view_flow.content).to be_has_key(:css)
+      expect(action_view.view_flow.content[:css]).to eq(expected_tags)
+    end
+  end
+
+  context 'call `content_for_once` and `content_for` with the same key' do
+    let(:content_for_block) { "<div><link rel='stylesheet' href='example1.css'/></div><link rel='stylesheet' href='example2.css'></link>".html_safe }
+    let(:content_for_once_block) { "<link rel='stylesheet' href='example1.css'/>".html_safe }
+    let(:expected_tags) { "<div><link rel='stylesheet' href='example1.css'/></div><link rel='stylesheet' href='example2.css'></link><link rel='stylesheet' href='example1.css'/>" }
+
+    it 'embeds each unique tags only once and stays `content_for` contents' do
+      action_view.content_for :css do
+        content_for_block
+      end
+
+      action_view.content_for_once :css do
+        content_for_once_block
       end
 
       expect(action_view.view_flow.content).to be_has_key(:css)


### PR DESCRIPTION
Too least test case, so v0.1.0 has critical bug.

- Broken with `javascript_include_tag`.
- Overwrite `content_for` contents with same key.
