### PR TITLE
Modify actionview version and activesupport version

### DIFF
--- a/content_for_once.gemspec
+++ b/content_for_once.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionview", "~> 4.2.6"
-  spec.add_dependency "activesupport", "~> 4.2.6"
+  spec.add_dependency "actionview", ">= 4.1.0"
+  spec.add_dependency "activesupport", ">= 4.1.0"
   spec.add_dependency "nokogiri"
 
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/lib/content_for_once/version.rb
+++ b/lib/content_for_once/version.rb
@@ -1,3 +1,3 @@
 module ContentForOnce
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Current gem's logic can be apply action view version `4.1.0`.
So now modify actionview and activesupport version dependencies :)