### PR TITLE
Fix return value to avoid hash printing

### DIFF
--- a/lib/content_for_once/helpers.rb
+++ b/lib/content_for_once/helpers.rb
@@ -16,6 +16,7 @@ module ContentForOnce
           map(&:to_s).select(&:present?).map {|e| e.gsub(/>\n/, '>') }.uniq.join("\n")
         @view_flow.set(name, _content)
       end
+      nil
     end
   end
 end

--- a/lib/content_for_once/version.rb
+++ b/lib/content_for_once/version.rb
@@ -1,3 +1,3 @@
 module ContentForOnce
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/spec/content_for_once_spec.rb
+++ b/spec/content_for_once_spec.rb
@@ -28,6 +28,10 @@ describe ContentForOnce do
       expect(action_view.view_flow.content).to be_has_key(:css)
       expect(action_view.view_flow.content[:css]).to eq(expected_tags)
     end
+
+    it 'returns nil' do
+      expect(action_view.content_for_once(:css) { first_given_block }).to be_nil
+    end
   end
 
   context 'call `content_for_once` and `content_for` with the same key' do


### PR DESCRIPTION
write the codes,

```haml
= content_for_once ...
```

then print the raw hash value in the view...

so, fixes to return nil from content_for_once.